### PR TITLE
Simplify build-system adding support for CMake generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,171 @@
+cmake_minimum_required(VERSION 3.12)
+project(bismon)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# update module path to ensure our custom modules are found (e.g Libonion)
+list(INSERT CMAKE_MODULE_PATH 0 ${bismon_SOURCE_DIR}/cmake)
+
+# Libonion
+find_package(Libonion REQUIRED)
+
+# glib, gtk+
+include(FindPkgConfig)
+pkg_check_modules(bm_gtk_package REQUIRED gtk+-3.0>=3.22 IMPORTED_TARGET)
+pkg_check_modules(bm_glib_package REQUIRED glib-2.0 IMPORTED_TARGET)
+
+# pthreads
+set(CMAKE_THREAD_PREFER_PTHREAD 1)
+set(THREADS_PREFER_PTHREAD_FLAG 1)
+find_package(Threads REQUIRED)
+
+# libbacktrace
+find_package(libbacktrace REQUIRED)
+
+# BM_makeconst
+add_executable(BM_makeconst BM_makeconst.cc)
+
+# crypt
+find_library(CRYPT_LIBRARY crypt)
+if(NOT CRYPT_LIBRARY)
+  message(FATAL_ERROR "error: crypt library not found")
+endif()
+
+# collect bismon sources
+file(GLOB bm_cfiles CONFIGURE_DEPENDS "[a-z]*BM.c")
+file(GLOB bm_cxxfiles CONFIGURE_DEPENDS "[a-z]*BM.cc")
+file(GLOB bm_webtemplates CONFIGURE_DEPENDS "[a-z]*BM.thtml")
+
+# timestamp the bismon program
+add_custom_command(
+  OUTPUT ${bismon_BINARY_DIR}/__timestamp.c
+  DEPENDS ${bm_cfiles} ${bm_cxxfiles}
+  COMMAND ${bismon_SOURCE_DIR}/timestamp-emit.sh ${bm_cfiles} ${bm_cxxfiles}
+  WORKING_DIRECTORY ${bismon_BINARY_DIR}
+  )
+list(APPEND bm_cfiles ${bismon_BINARY_DIR}/__timestamp.c)
+
+# make a XXX_BM.const.h header with constants in XXX_BM.c
+set(bm_const_hfiles)
+foreach(bm_cfile IN LISTS bm_cfiles)
+  get_filename_component(bm_cfile_basename ${bm_cfile} NAME_WE)
+  set(h_output ${bismon_BINARY_DIR}/${bm_cfile_basename}.const.h)
+  add_custom_command(
+    OUTPUT ${h_output}
+    DEPENDS ${bm_cfile}
+    COMMAND BM_makeconst -H ${h_output} ${bm_cfile}
+    WORKING_DIRECTORY ${bismon_BINARY_DIR}
+    COMMENT "BMCONSTH ${h_output}"
+    )
+  list(APPEND bm_const_hfiles ${h_output})
+endforeach()
+
+# make the _bm_allconsts.c file
+set(c_output ${bismon_BINARY_DIR}/_bm_allconsts.c)
+add_custom_command(
+  OUTPUT ${c_output}
+  DEPENDS ${bm_cfiles}
+  COMMAND BM_makeconst -C ${c_output} ${bm_cfiles}
+  WORKING_DIRECTORY ${bismon_BINARY_DIR}
+  COMMENT "BMALLCONSTSC ${c_output}"
+  )
+list(APPEND bm_cfiles ${c_output})
+
+# build from webtemplates
+foreach(template IN LISTS bm_webtemplates)
+  get_filename_component(template_basename ${template} NAME_WE)
+  set(c_output ${bismon_BINARY_DIR}/${template_basename}.c)
+  set(h_output ${bismon_BINARY_DIR}/_${template_basename}.h)
+  add_custom_command(
+    OUTPUT ${c_output} ${h_output}
+    DEPENDS ${template}
+    COMMAND ${Libonion_OTEMPLATE_EXECUTABLE} -a ${h_output} ${template} ${c_output}
+    WORKING_DIRECTORY ${bismon_BINARY_DIR}
+    )
+  list(APPEND bm_cfiles ${c_output})
+endforeach()
+
+# bismon executable
+add_executable(bismon
+  ${bm_cfiles}
+  ${bm_cxxfiles}
+  ${bm_const_hfiles}
+  )
+target_compile_definitions(bismon
+  PRIVATE
+    BISMONION
+    BISMONGTK
+    GDK_DISABLE_DEPRECATED
+    GTK_DISABLE_DEPRECATED
+  )
+target_link_libraries(bismon
+  PRIVATE
+    ${CMAKE_DL_LIBS}
+    ${CRYPT_LIBRARY}
+    libbacktrace::libbacktrace
+    Libonion::Libonion
+    Libonion::LibonionCpp
+    PkgConfig::bm_glib_package
+    PkgConfig::bm_gtk_package
+    Threads::Threads
+  )
+
+# bismon executable symlinks
+add_custom_command(TARGET bismon POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:bismon> bismonion
+  COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:bismon> bismongtk
+  WORKING_DIRECTORY ${bismon_BINARY_DIR}
+  )
+
+function(bm_add_module src type)
+  get_filename_component(name ${src} NAME_WE)
+
+  # id, md5
+  string(REGEX REPLACE "[0-9a-zA-Z]+(\_.+)" "\\1" id ${name})
+  file(MD5 ${src} md5)
+
+  message(STATUS "  ${type} [id:${id}, md5:${md5}]")
+
+  add_library(${name} MODULE ${src})
+  target_link_libraries(${name}
+    PRIVATE
+      PkgConfig::bm_glib_package)
+  target_compile_definitions(${name}
+    PRIVATE
+      BISMON_MODID=${id}
+      BISMON_MOMD5="${md5}"
+      ${type}
+    )
+  set_target_properties(${name}
+    PROPERTIES
+      OUTPUT_NAME "${name}"
+      PREFIX ""
+      LIBRARY_OUTPUT_DIRECTORY "modubin"
+    )
+  get_filename_component(src_name ${src} NAME)
+  add_custom_command(TARGET ${name} PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${bismon_BINARY_DIR}/modubin
+    COMMAND ${CMAKE_COMMAND} -E copy ${src} ${bismon_BINARY_DIR}/modules/${src_name}
+    )
+endfunction()
+
+# add modules
+message(STATUS "Adding bismon modules")
+
+file(GLOB bm_modules CONFIGURE_DEPENDS "modules/modbm_*.c")
+foreach(bm_module IN LISTS bm_modules)
+  bm_add_module(${bm_module} BISMON_PERSISTENT_MODULE)
+endforeach()
+
+file(GLOB bm_modules CONFIGURE_DEPENDS "modules/tmpmobm_*.c")
+foreach(bm_module IN LISTS bm_modules)
+  bm_add_module(${bm_module} BISMON_TEMPORARY_MODULE)
+endforeach()
+
+# Copy *.bmon to build directory
+file(GLOB bmon_stores RELATIVE ${bismon_SOURCE_DIR} CONFIGURE_DEPENDS "*.bmon")
+foreach(bmon_store IN LISTS bmon_stores)
+  configure_file(${bmon_store} ${bismon_BINARY_DIR}/${bmon_store} COPYONLY)
+endforeach()

--- a/cmake/FindLibonion.cmake
+++ b/cmake/FindLibonion.cmake
@@ -1,0 +1,59 @@
+
+#
+# This was file is based of CMake/Module/FindZLIB.cmake and was created to
+# demonstrate the use of CMake to build the "bismon" project.
+#
+# What should really be done is improving the onion project so that it
+# created a "config-file" package. Since it already uses CMake, it should
+# be fairly straighforward.
+#
+# See https://cmake.org/cmake/help/v3.12/manual/cmake-packages.7.html
+#
+
+# Hints
+# ^^^^^
+#
+# A user may set ``Libonion_ROOT`` to a libonion installation root to tell this
+# module where to look.
+#
+
+# Search Libonion_DIR first if it is set.
+find_program(Libonion_OTEMPLATE_EXECUTABLE otemplate PATH_SUFFIXES bin)
+find_library(Libonion_CPP_LIBRARY onioncpp PATH_SUFFIXES lib)
+find_library(Libonion_C_LIBRARY onion PATH_SUFFIXES lib)
+#find_library(Libonion_C_STATIC_LIBRARY onion_static PATH_SUFFIXES lib)
+find_path(Libonion_INCLUDE_DIR onion/onion.h PATH_SUFFIXES include)
+
+mark_as_advanced(Libonion_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libonion
+  REQUIRED_VARS
+    Libonion_OTEMPLATE_EXECUTABLE
+    Libonion_CPP_LIBRARY
+    Libonion_INCLUDE_DIR
+  #VERSION_VAR Libonion_VERSION_STRING
+)
+
+if(Libonion_FOUND)
+    set(Libonion_INCLUDE_DIRS ${Libonion_INCLUDE_DIR})
+    set(Libonion_LIBRARIES ${Libonion_CPP_LIBRARY} ${Libonion_C_LIBRARY})
+
+    if(NOT TARGET Libonion::Libonion)
+      add_library(Libonion::Libonion UNKNOWN IMPORTED)
+      set_target_properties(Libonion::Libonion PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Libonion_INCLUDE_DIRS}")
+
+      set_property(TARGET Libonion::Libonion APPEND PROPERTY
+        IMPORTED_LOCATION "${Libonion_C_LIBRARY}")
+    endif()
+
+    if(NOT TARGET Libonion::LibonionCpp)
+      add_library(Libonion::LibonionCpp UNKNOWN IMPORTED)
+      set_target_properties(Libonion::LibonionCpp PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Libonion_INCLUDE_DIRS}")
+
+      set_property(TARGET Libonion::LibonionCpp APPEND PROPERTY
+        IMPORTED_LOCATION "${Libonion_CPP_LIBRARY}")
+    endif()
+endif()

--- a/cmake/Findlibbacktrace.cmake
+++ b/cmake/Findlibbacktrace.cmake
@@ -1,0 +1,69 @@
+#.rst:
+# Findlibbacktrace
+# ----------------
+#
+# Find the libbacktrace headers and library.
+# See https://github.com/ianlancetaylor/libbacktrace
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines :prop_tgt:`IMPORTED` target ``libbacktrace::libbacktrace``, if
+# libbacktrace has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# ``libbacktrace_INCLUDE_DIRS``
+#   The include directories needed to use libbacktrace header.
+# ``libbacktrace_LIBRARIES``
+#   The libraries (linker flags) needed to use libbacktrace, if any.
+# ``libbacktrace_FOUND``
+#   Is set if and only if libbacktrace support detected.
+#
+# The following cache variables are also available to set or use:
+#
+# ``libbacktrace_LIBRARY``
+#   The external library providing libbacktrace, if any.
+# ``libbacktrace_INCLUDE_DIR``
+#   The directory holding the libbacktrace header.
+#
+
+include(CMakePushCheckState)
+include(CheckSymbolExists)
+
+find_path(libbacktrace_INCLUDE_DIR "backtrace.h" PATH_SUFFIXES include)
+find_library(libbacktrace_LIBRARY "backtrace" PATH_SUFFIXES lib)
+
+#if (NOT DEFINED libbacktrace_LIBRARY)
+#  # First, check if we already have backtrace(), e.g., in libc
+#  cmake_push_check_state(RESET)
+#  set(CMAKE_REQUIRED_INCLUDES ${libbacktrace_INCLUDE_DIR})
+#  set(CMAKE_REQUIRED_QUIET ${libbacktrace_FIND_QUIETLY})
+#  check_symbol_exists("backtrace_create_state" "backtrace.h" HAVE_BACKTRACE_CREATE_STATE)
+#  check_symbol_exists("backtrace_full" "backtrace.h" HAVE_BACKTRACE_FULL)
+#  cmake_pop_check_state()
+#endif()
+
+mark_as_advanced(libbacktrace_INCLUDE_DIR libbacktrace_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libbacktrace
+  REQUIRED_VARS
+    libbacktrace_INCLUDE_DIR
+    libbacktrace_LIBRARY
+)
+
+if(libbacktrace_FOUND)
+    set(libbacktrace_INCLUDE_DIRS ${libbacktrace_INCLUDE_DIR})
+    set(libbacktrace_LIBRARIES ${libbacktrace_LIBRARY})
+
+    if(NOT TARGET libbacktrace::libbacktrace)
+      add_library(libbacktrace::libbacktrace UNKNOWN IMPORTED)
+      set_target_properties(libbacktrace::libbacktrace PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${libbacktrace_INCLUDE_DIRS}")
+
+      set_property(TARGET libbacktrace::libbacktrace APPEND PROPERTY
+        IMPORTED_LOCATION "${libbacktrace_LIBRARY}")
+    endif()
+endif()

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,55 @@
+#/usr/bin/env bash
+
+set -xeu
+set -o pipefail
+
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+pushd $script_dir/../../
+
+sudo apt-get update
+sudo apt-get install -y glib-2.0 gtk+-3.0
+
+# Documentation
+# sudo apt-get install -y markdown tardy texlive hevea
+# texlive-full: 1GB ?
+
+# Compiler
+# sudo apt-get install -y gcc-8 g++-8 gcc-8-plugin-dev libgccjit-8-dev
+
+#
+# Libonion
+#
+if [[ ! -d libonion ]]; then
+  git clone https://github.com/davidmoreno/onion libonion
+fi
+
+mkdir -p libonion-build
+mkdir -p libonion-install
+
+Libonion_ROOT=$(pwd)/libonion-install
+cmake -Hlibonion -Blibonion-build -G Ninja \
+  -DCMAKE_INSTALL_PREFIX:PATH=${Libonion_ROOT} \
+  -DONION_EXAMPLES:BOOL=OFF
+cmake --build libonion-build --target install
+
+#
+# libbacktrace
+#
+if [[ ! -d libbacktrace ]]; then
+  git clone https://github.com/ianlancetaylor/libbacktrace.git
+fi
+pushd libbacktrace
+libbacktrace_ROOT=$(pwd)/../libbacktrace-install
+./configure --prefix=${libbacktrace_ROOT}
+make -j4
+make install
+popd
+
+#
+# bismon
+#
+cmake -G Ninja -Hbismon -Bbismon-build \
+  -DLibonion_ROOT:PATH=${Libonion_ROOT} \
+  -Dlibbacktrace_ROOT:PATH=${libbacktrace_ROOT}
+cmake --build bismon-build
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,19 @@
+#/usr/bin/env bash
+
+set -xeu
+set -o pipefail
+
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+pushd $script_dir/../../bismon-build
+
+password_BM=$(pwd)/passwords_BM
+touch ${password_BM}
+chmod u+rw,go-rwx ${password_BM}
+
+contributors_BM=$(pwd)/contributors_BM
+touch $contributors_BM
+
+./bismonion --contributor="Alan Turing;alan@fake.email;turing@localhost" --batch --dump-after-load=.
+
+echo "Alan Turing:mypass!123456" > /tmp/addpassbismon
+./bismonion--add-passwords=/tmp/addpassbismon --batch --dump-after-load=.


### PR DESCRIPTION
Following your [recent post on the ninja-build](https://groups.google.com/forum/#!topic/ninja-build/cCn5GGB-j8I) list, I got curious about bismon .. and I ended up improving its build system.

To facilitate building the project (and potentially streamlining its maintenance), this PR adds support for generating the build system using [CMake](http://cmake.org/).

In a nutshell, you can now configure the project with [generator](https://cmake.org/cmake/help/v3.12/manual/cmake-generators.7.html) like `Ninja` or `Unix Makefiles` (the default). Assuming all dependencies are installed, generating the ninja build system will be as simple as this:

```
git clone https://github.com/jcfr/bismon.git -b generate-ninja-build-using-cmake
mkdir bismon-build && cd $_
cmake -G Ninja ../bismon
ninja
```

But, it can also be configured with dependency in arbitrary location. For example, using the [build.sh](https://github.com/jcfr/bismon/blob/464c7200a3a054e9ca804da822332918d35838e2/scripts/build.sh)
script, Libonion and libbacktrace will be downloaded, built and installed in a custom location without
the need to "pollute" `/usr/local`. Given a custom location of Libonion and libbacktrace, the project
can then be configured using:

```
cmake -G Ninja -Hbismon -Bbismon-build \
  -DLibonion_ROOT:PATH=${Libonion_ROOT} \
  -Dlibbacktrace_ROOT:PATH=${libbacktrace_ROOT}
```

### Features implemented

* support generation of `Unix Makefiles` or `Ninja` build-system
* clear error message reported if a dependency can't be found
* decoupling of source and build directory.
* automatic update of build-system (when running `ninja`) if any source file, header or web-template is modified
* generation of:
  * `__timestamp.c`
  * `XXX_BM.const.h` headers
  * `_bm_allconsts.c`
  * source and header files using webtemplates
* compilation of `bismon` and `BM_makeconst` executables
* compilation of both persistent and temporary modules
* creation of `bismonion` and `bismongtk` symlinks
* copy of the `*.bmon` store files to the build directory
* only ~160 lines in the `CMakeLists.txt`

For reference, starting from a bismon checkout, generation of the ninja buildsystem and full rebuild (including
regeneration of `__timestamp.c`, `XXX_BM.const.h`, ..., the two persistent modules) takes ~6 seconds.

### Testing

CMake also provides an easy and straightforward approach for adding and running tests. I would be happy to help
you adding few tests.

### Continuous integration

Setting up continuous integration using [CircleCI](http://circleci.com/) would be nice too. That way
each time a PR is created or each time master is updated, the project would be compiled (and ideally
tests executed) 

Since CircleCI provides a first class support for docker container, we could easily have a docker container 
with prerequisites installed.

The idea would be to leverage the [dockbuild](https://github.com/dockbuild/dockbuild) compiling environment
that provide a ready to use docker image.


### Reproducible environment

For example, I used the `dockbuild/ubuntu1804-gcc7` image:

```
cd /tmp
mkdir /tmp/bismon-scratch
git clone https://github.com/jcfr/bismon.git -b generate-ninja-build-using-cmake
```

Then, pull the associated docker image and create convenience script:

```
cd /tmp/bismon-scratch
docker pull dockbuild/ubuntu1804-gcc7
docker run -ti --rm dockbuild/ubuntu1804-gcc7 > dockbuild-ubuntu1804-gcc7
fromdos dockbuild-ubuntu1804-gcc7 
chmod u+x dockbuild-ubuntu1804-gcc7
```

Finally, shell into the environment and run the [build.sh](https://github.com/jcfr/bismon/blob/464c7200a3a054e9ca804da822332918d35838e2/scripts/build.sh) script. The script will install
gtk, glib, build Libonion, libbacktrace and build bismon using the `ubuntu1804-gcc7` environment.
The build artifacts will be generated in your current directory (`/tmp/bismon-scratch`) but nothing
will be installed on your real system.

```
dockbuild-ubuntu1804-gcc7 bash
./bismon/scripts/build.sh
```

I also got started writting a [test.sh](https://github.com/jcfr/bismon/blob/464c7200a3a054e9ca804da822332918d35838e2/scripts/test.sh) script but i would appreciate your help fixing it.

```
./bismon/scripts/test.sh
```

To speed up the build (and eventually testing), we could also look into deriving the dockbuild image
and have gtk, glib and even g++8 pre-installed.


Let me know if you have any questions,

